### PR TITLE
Fix info deletion on cached entities

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,7 +16,7 @@ To be released.
 - Fixed a bug that raised :exc:`~urllib.error.HTTPError` when
   non-existent `Entity` was requested.  [:pr:`11`]
 - Fixed a bug that raised :exc:`KeyError` when accessing an image more than
-  once and MemoryCache was enabled [:pr:`24`]
+  once and :class:`~wikidata.cache.MemoryCachePolicy` was enabled.  [:pr:`24`]
 
 
 Version 0.6.1

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,6 +15,9 @@ To be released.
   [:pr:`11`]
 - Fixed a bug that raised :exc:`~urllib.error.HTTPError` when
   non-existent `Entity` was requested.  [:pr:`11`]
+- Fixed a bug that raised :exc:`KeyError` when accessing an image more than
+  once and MemoryCache was enabled [:pr:`24`]
+
 
 Version 0.6.1
 -------------

--- a/wikidata/commonsmedia.py
+++ b/wikidata/commonsmedia.py
@@ -94,7 +94,7 @@ class File:
                             repr(result['error']))
         query = result['query']
         assert isinstance(query, collections.abc.Mapping)
-        _, self.data = query['pages'].popitem()
+        self.data = next(iter(query['pages'].values()))
 
     def __repr__(self) -> str:
         return '<{0.__module__}.{0.__qualname__} {1!r}>'.format(


### PR DESCRIPTION
popitem() removes the item from the list. When using the MemoryCache option, this will cause an Exception because the expected element will not be present when accessing the entity more than once.

This change will keep the elements. The order is not guaranteed (which is good?)