### PR TITLE
Add tox to setup.cfg options.extras_require tests

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,6 +15,7 @@ To be released.
   [:pr:`11`]
 - Fixed a bug that raised :exc:`~urllib.error.HTTPError` when
   non-existent `Entity` was requested.  [:pr:`11`]
+- Added `tox` to `tests` extra-install.  [:pr:`25`]
 
 Version 0.6.1
 -------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ tests =
     flake8-import-order-spoqa
     pytest ~= 4.6.11
     pytest-flake8 ~= 1.0.6
+    tox
 mypy =
     mypy >= 0.782
 


### PR DESCRIPTION
This makes it easier to test / reproduce the CI environment locally.