### PR TITLE
Support time datatype with precision 9 (year only)

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,7 +15,7 @@ To be released.
   [:pr:`11`]
 - Fixed a bug that raised :exc:`~urllib.error.HTTPError` when
   non-existent `Entity` was requested.  [:pr:`11`]
-- Add support for `time` datatypes with precision `9` (year-only).  [:pr:`26`]
+- Added support for `time` datatypes with precision `9` (year-only).  [:pr:`26`]
 
 Version 0.6.1
 -------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,6 +15,7 @@ To be released.
   [:pr:`11`]
 - Fixed a bug that raised :exc:`~urllib.error.HTTPError` when
   non-existent `Entity` was requested.  [:pr:`11`]
+- Add support for `time` datatypes with precision `9` (year-only).  [:pr:`26`]
 
 Version 0.6.1
 -------------

--- a/tests/datavalue_test.py
+++ b/tests/datavalue_test.py
@@ -86,6 +86,7 @@ def test_decoder__time(datatype: str, fx_client: Client):
         })
     assert (datetime.date(2017, 2, 22) ==
             d(fx_client, datatype, other_value(precision=11)))
+    assert 2017 == d(fx_client, datatype, other_value(precision=9))
     utc = datetime.timezone.utc
     assert (datetime.datetime(2017, 2, 22, 2, 53, 12, tzinfo=utc) ==
             d(fx_client, datatype, valid))
@@ -127,7 +128,7 @@ def test_decoder__time(datatype: str, fx_client: Client):
         d(fx_client, datatype, other_value(precision=None))
         # precision field is missing
     for p in range(1, 15):
-        if p in (11, 14):
+        if p in (9, 11, 14):
             continue
         with raises(DatavalueError):
             d(fx_client, datatype, other_value(precision=p))

--- a/wikidata/datavalue.py
+++ b/wikidata/datavalue.py
@@ -197,6 +197,7 @@ class Decoder:
         except KeyError:
             raise DatavalueError('precision field is missing', datavalue)
         if precision == 9:
+            # The time only specifies the year.
             return int(time[1:5])
         if precision == 11:
             return datetime.date(int(time[1:5]), int(time[6:8]),

--- a/wikidata/datavalue.py
+++ b/wikidata/datavalue.py
@@ -149,7 +149,8 @@ class Decoder:
     def time(self,
              client: Client,
              datavalue: Mapping[str, object]) -> Union[datetime.date,
-                                                       datetime.datetime]:
+                                                       datetime.datetime,
+                                                       int]:
         value = datavalue['value']
         if not isinstance(value, collections.abc.Mapping):
             raise DatavalueError(
@@ -195,6 +196,8 @@ class Decoder:
             precision = value['precision']
         except KeyError:
             raise DatavalueError('precision field is missing', datavalue)
+        if precision == 9:
+            return int(time[1:5])
         if precision == 11:
             return datetime.date(int(time[1:5]), int(time[6:8]),
                                  int(time[9:11]))
@@ -205,7 +208,7 @@ class Decoder:
             ).replace(tzinfo=datetime.timezone.utc)
         else:
             raise DatavalueError(
-                '{!r}: time precision other than 11 or 14 is '
+                '{!r}: time precision other than 9, 11 or 14 is '
                 'unsupported'.format(precision),
                 datavalue
             )


### PR DESCRIPTION
Fixes https://github.com/dahlia/wikidata/issues/22 and https://github.com/dahlia/wikidata/issues/6

Supports year-only `time`s by returning an int (ref: https://github.com/dahlia/wikidata/issues/22#issuecomment-626169884)