### PR TITLE
Add support for parsing globecoordinate data type

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,6 +15,7 @@ To be released.
   [:pr:`11`]
 - Fixed a bug that raised :exc:`~urllib.error.HTTPError` when
   non-existent `Entity` was requested.  [:pr:`11`]
+- Added support for decoding the `globe-coordinate` datatype.  [:pr:`28`]
 
 Version 0.6.1
 -------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,7 +15,7 @@ To be released.
   [:pr:`11`]
 - Fixed a bug that raised :exc:`~urllib.error.HTTPError` when
   non-existent `Entity` was requested.  [:pr:`11`]
-- Added support for decoding the `globe-coordinate` datatype.  [:pr:`28`]
+- Added support for decoding the ``globe-coordinate`` datatype.  [:pr:`28`]
 
 Version 0.6.1
 -------------

--- a/docs/wikidata.rst
+++ b/docs/wikidata.rst
@@ -9,4 +9,5 @@
       wikidata/commonsmedia
       wikidata/datavalue
       wikidata/entity
+      wikidata/globecoordinate
       wikidata/multilingual

--- a/docs/wikidata/globecoordinate.rst
+++ b/docs/wikidata/globecoordinate.rst
@@ -1,0 +1,3 @@
+
+.. automodule:: wikidata.globecoordinate
+   :members:

--- a/tests/datavalue_test.py
+++ b/tests/datavalue_test.py
@@ -6,7 +6,7 @@ from pytest import mark, raises
 from wikidata.client import Client
 from wikidata.commonsmedia import File
 from wikidata.datavalue import DatavalueError, Decoder
-from wikidata.entity import Entity
+from wikidata.entity import Entity, EntityId
 from wikidata.globecoordinate import GlobeCoordinate
 from wikidata.multilingual import MonolingualText
 
@@ -167,6 +167,6 @@ def test_decoder_globecoordinate(fx_client: Client):
     })
     gold = GlobeCoordinate(70.1525,
                            70.1525,
-                           fx_client.get("Q111"),
+                           fx_client.get(EntityId("Q111")),
                            0.0002777777777777778,)
     assert decoded == gold

--- a/tests/datavalue_test.py
+++ b/tests/datavalue_test.py
@@ -7,6 +7,7 @@ from wikidata.client import Client
 from wikidata.commonsmedia import File
 from wikidata.datavalue import DatavalueError, Decoder
 from wikidata.entity import Entity
+from wikidata.globecoordinate import GlobeCoordinate
 from wikidata.multilingual import MonolingualText
 
 
@@ -151,3 +152,21 @@ def test_decoder_commonsMedia__string(fx_client: Client):
           {'value': 'The Fabs.JPG', 'type': 'string'})
     assert isinstance(f, File)
     assert f.title == 'File:The Fabs.JPG'
+
+
+def test_decoder_globecoordinate(fx_client: Client):
+    d = Decoder()
+    decoded = d(fx_client, 'globe-coordinate', {
+        'value': {
+            "latitude": 70.1525,
+            "longitude": 70.1525,
+            "precision": 0.0002777777777777778,
+            "globe": "http://www.wikidata.org/entity/Q111"
+        },
+        'type': 'globecoordinate'
+    })
+    gold = GlobeCoordinate(70.1525,
+                           70.1525,
+                           fx_client.get("Q111"),
+                           0.0002777777777777778,)
+    assert decoded == gold

--- a/tests/globecoordinate_test.py
+++ b/tests/globecoordinate_test.py
@@ -1,7 +1,7 @@
 from pytest import fixture
 
 from wikidata.client import Client
-from wikidata.entity import Entity
+from wikidata.entity import Entity, EntityId
 from wikidata.globecoordinate import GlobeCoordinate
 
 
@@ -12,7 +12,7 @@ def fx_globecoordinate() -> GlobeCoordinate:
         latitude=70.1525,
         longitude=70.1525,
         precision=0.0002777777777777778,
-        globe=client.get("Q111"))
+        globe=client.get(EntityId("Q111")))
 
 
 def test_globecoordinate_value(fx_globecoordinate: GlobeCoordinate):

--- a/tests/globecoordinate_test.py
+++ b/tests/globecoordinate_test.py
@@ -1,0 +1,23 @@
+from pytest import fixture
+
+from wikidata.client import Client
+from wikidata.entity import Entity
+from wikidata.globecoordinate import GlobeCoordinate
+
+
+@fixture
+def fx_globecoordinate() -> GlobeCoordinate:
+    client = Client()
+    return GlobeCoordinate(**{
+        "latitude": 70.1525,
+        "longitude": 70.1525,
+        "precision": 0.0002777777777777778,
+        "globe": client.get("Q111")})
+
+
+def test_globecoordinate_value(fx_globecoordinate: GlobeCoordinate):
+    assert fx_globecoordinate.latitude == 70.1525
+    assert fx_globecoordinate.longitude == 70.1525
+    assert fx_globecoordinate.precision == 0.0002777777777777778
+    assert isinstance(fx_globecoordinate.globe, Entity)
+    assert fx_globecoordinate.globe.id == "Q111"

--- a/tests/globecoordinate_test.py
+++ b/tests/globecoordinate_test.py
@@ -8,11 +8,11 @@ from wikidata.globecoordinate import GlobeCoordinate
 @fixture
 def fx_globecoordinate() -> GlobeCoordinate:
     client = Client()
-    return GlobeCoordinate(**{
-        "latitude": 70.1525,
-        "longitude": 70.1525,
-        "precision": 0.0002777777777777778,
-        "globe": client.get("Q111")})
+    return GlobeCoordinate(
+        latitude=70.1525,
+        longitude=70.1525,
+        precision=0.0002777777777777778,
+        globe=client.get("Q111"))
 
 
 def test_globecoordinate_value(fx_globecoordinate: GlobeCoordinate):

--- a/tests/globecoordinate_test.py
+++ b/tests/globecoordinate_test.py
@@ -21,3 +21,9 @@ def test_globecoordinate_value(fx_globecoordinate: GlobeCoordinate):
     assert fx_globecoordinate.precision == 0.0002777777777777778
     assert isinstance(fx_globecoordinate.globe, Entity)
     assert fx_globecoordinate.globe.id == "Q111"
+
+
+def test_globecoordinate_repr(fx_globecoordinate: GlobeCoordinate):
+    assert (repr(fx_globecoordinate) ==
+            ("wikidata.globecoordinate.GlobeCoordinate(70.1525, 70.1525, "
+             "<wikidata.entity.Entity Q111>, 0.0002777777777777778)"))

--- a/wikidata/datavalue.py
+++ b/wikidata/datavalue.py
@@ -16,7 +16,7 @@ but only need to satify::
 """
 import collections.abc
 import datetime
-from typing import Any, TYPE_CHECKING, Mapping, Union
+from typing import TYPE_CHECKING, Any, Mapping, Union
 
 from .client import Client
 from .commonsmedia import File

--- a/wikidata/datavalue.py
+++ b/wikidata/datavalue.py
@@ -16,10 +16,11 @@ but only need to satify::
 """
 import collections.abc
 import datetime
-from typing import TYPE_CHECKING, Mapping, Union
+from typing import Any, TYPE_CHECKING, Mapping, Union
 
 from .client import Client
 from .commonsmedia import File
+from .globecoordinate import GlobeCoordinate
 from .multilingual import MonolingualText
 if TYPE_CHECKING:
     from .entity import Entity  # noqa: F401
@@ -215,6 +216,22 @@ class Decoder:
                         datavalue: Mapping[str, object]) -> MonolingualText:
         pair = datavalue['value']
         return MonolingualText(pair['text'], pair['language'])  # type: ignore
+
+    def globecoordinate(self,
+                        client: Client,
+                        datavalue: Mapping[str, Any]) -> GlobeCoordinate:
+        pair = datavalue['value']
+        # Try to split out the entity from the globe string.
+        globe_entity = pair["globe"].split("http://www.wikidata.org/entity/")
+        if len(globe_entity) != 2:
+            raise DatavalueError(
+                "Globe string {} does not appear to be a "
+                "valid WikiData entity URL".format(pair["globe"]))
+        entity_id = globe_entity[1]
+        return GlobeCoordinate(pair['latitude'],
+                               pair['longitude'],
+                               client.get(entity_id),
+                               pair['precision'])
 
     def commonsMedia__string(self,
                              client: Client,

--- a/wikidata/globecoordinate.py
+++ b/wikidata/globecoordinate.py
@@ -1,3 +1,7 @@
+""":mod:`wikidata.globecoordinate` --- Globe coordinate
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+"""
 from .entity import Entity
 
 __all__ = 'GlobeCoordinate',

--- a/wikidata/globecoordinate.py
+++ b/wikidata/globecoordinate.py
@@ -44,3 +44,13 @@ class GlobeCoordinate:
                      self.latitude,
                      self.globe,
                      self.precision))
+
+    def __repr__(self) -> str:
+        return ('{0.__module__}.{0.__qualname__}({1!r}, '
+                '{2!r}, {3!r}, {4!r})').format(
+                    type(self),
+                    self.latitude,
+                    self.longitude,
+                    self.globe,
+                    self.precision
+                )

--- a/wikidata/globecoordinate.py
+++ b/wikidata/globecoordinate.py
@@ -1,0 +1,42 @@
+from .entity import Entity
+
+__all__ = 'GlobeCoordinate',
+
+
+class GlobeCoordinate:
+    """
+    Literal data for a geographical position given as a latitude-longitude pair
+    in gms or decimal degrees for the given stellar body.
+    """
+
+    latitude = None  # type: float
+    longitude = None  # type: float
+    globe = None  # type: Entity
+    precision = None  # type: float
+
+    def __init__(self,
+                 latitude: float,
+                 longitude: float,
+                 globe: Entity,
+                 precision: float) -> None:
+        self.latitude = latitude
+        self.longitude = longitude
+        self.globe = globe
+        self.precision = precision
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, type(self)):
+            raise TypeError(
+                'expected an instance of {0.__module__}.{0.__qualname__}, '
+                'not {1!r}'.format(type(self), other)
+            )
+        return (other.latitude == self.latitude and
+                other.longitude == self.longitude and
+                other.globe == self.globe and
+                other.precision == self.precision)
+
+    def __hash__(self):
+        return hash((self.longitude,
+                     self.latitude,
+                     self.globe,
+                     self.precision))


### PR DESCRIPTION
This PR introduces changes to support parsing globecoordinates—this is quite important for ciites / other locations in the world. See https://www.wikidata.org/wiki/Help:Data_type#Globe_coordinate for official wikidata docs

I've been using the coordinate on https://www.wikidata.org/wiki/Q520 as an example, since it uses a nonstandard globe (Mars)