### PR TITLE
Add support for parsing quantity datatype

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,6 +16,7 @@ To be released.
 - Fixed a bug that raised :exc:`~urllib.error.HTTPError` when
   non-existent `Entity` was requested.  [:pr:`11`]
 - Added support for `time` datatypes with precision `9` (year-only).  [:pr:`26`]
+- Added support for decoding the ``quantity`` datatype.  [:pr:`28`]
 
 Version 0.6.1
 -------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,7 +17,6 @@ To be released.
 - Added support for decoding the ``globe-coordinate`` datatype.  [:pr:`28`]
 - Fixed a bug that raised :exc:`~urllib.error.HTTPError` when
   non-existent `Entity` was requested.  [:pr:`11`]
-- Added support for `time` datatypes with precision `9` (year-only).  [:pr:`26`]
 - Added support for decoding the ``quantity`` datatype.  [:pr:`29`]
 - Fixed a bug that raised :exc:`KeyError` when accessing an image more than
   once and :class:`~wikidata.cache.MemoryCachePolicy` was enabled.  [:pr:`24`]

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,7 +16,7 @@ To be released.
 - Fixed a bug that raised :exc:`~urllib.error.HTTPError` when
   non-existent `Entity` was requested.  [:pr:`11`]
 - Added support for `time` datatypes with precision `9` (year-only).  [:pr:`26`]
-- Added support for decoding the ``quantity`` datatype.  [:pr:`28`]
+- Added support for decoding the ``quantity`` datatype.  [:pr:`29`]
 
 Version 0.6.1
 -------------

--- a/docs/wikidata.rst
+++ b/docs/wikidata.rst
@@ -10,3 +10,4 @@
       wikidata/datavalue
       wikidata/entity
       wikidata/multilingual
+      wikidata/quantity

--- a/docs/wikidata/quantity.rst
+++ b/docs/wikidata/quantity.rst
@@ -1,0 +1,3 @@
+
+.. automodule:: wikidata.quantity
+   :members:

--- a/tests/datavalue_test.py
+++ b/tests/datavalue_test.py
@@ -189,6 +189,7 @@ def test_decoder_quantity_unitless(fx_client: Client):
         lower_bound=None,
         upper_bound=None,
         unit=None)
+    assert decoded == gold
 
 
 def test_decoder_globecoordinate(fx_client: Client):

--- a/tests/datavalue_test.py
+++ b/tests/datavalue_test.py
@@ -6,8 +6,9 @@ from pytest import mark, raises
 from wikidata.client import Client
 from wikidata.commonsmedia import File
 from wikidata.datavalue import DatavalueError, Decoder
-from wikidata.entity import Entity
+from wikidata.entity import Entity, EntityId
 from wikidata.multilingual import MonolingualText
+from wikidata.quantity import Quantity
 
 
 def test_datavalue_error():
@@ -152,3 +153,39 @@ def test_decoder_commonsMedia__string(fx_client: Client):
           {'value': 'The Fabs.JPG', 'type': 'string'})
     assert isinstance(f, File)
     assert f.title == 'File:The Fabs.JPG'
+
+
+def test_decoder_quantity_with_unit(fx_client: Client):
+    d = Decoder()
+    decoded = d(fx_client, 'quantity', {
+        'value': {
+            "amount": "+610.13",
+            "lower_bound": "+610.12",
+            "upper_bound": "+610.14",
+            "unit": "http://www.wikidata.org/entity/Q828224"
+        },
+        'type': 'quantity'
+    })
+    gold = Quantity(
+        amount=610.13,
+        lower_bound=610.12,
+        upper_bound=610.14,
+        unit=fx_client.get(EntityId("Q828224")))
+    assert decoded == gold
+
+
+def test_decoder_quantity_unitless(fx_client: Client):
+    d = Decoder()
+    decoded = d(fx_client, 'quantity', {
+        'value': {
+            "amount": "+12",
+            "unit": "1"
+        },
+        'type': 'quantity'
+    })
+    gold = Quantity(
+        amount=12,
+        lower_bound=None,
+        upper_bound=None,
+        unit=None)
+    assert decoded == gold

--- a/tests/quantity_test.py
+++ b/tests/quantity_test.py
@@ -1,0 +1,52 @@
+from pytest import fixture
+
+from wikidata.client import Client
+from wikidata.entity import Entity, EntityId
+from wikidata.quantity import Quantity
+
+
+@fixture
+def fx_quantity_unitless() -> Quantity:
+    # From Q605704 (dozen)
+    return Quantity(
+        amount=12,
+        lower_bound=None,
+        upper_bound=None,
+        unit=None)
+
+
+@fixture
+def fx_quantity_with_unit() -> Quantity:
+    client = Client()
+    # From Q520
+    return Quantity(
+        amount=610.13,
+        lower_bound=610.12,
+        upper_bound=610.14,
+        unit=client.get(EntityId("Q828224")))
+
+
+def test_quantity_unitless_value(fx_quantity_unitless: Quantity):
+    assert fx_quantity_unitless.amount == 12
+    assert fx_quantity_unitless.lower_bound is None
+    assert fx_quantity_unitless.upper_bound is None
+    assert fx_quantity_unitless.unit is None
+
+
+def test_quantity_unitless_repr(fx_quantity_unitless: Quantity):
+    assert (repr(fx_quantity_unitless) ==
+            ("wikidata.quantity.Quantity(12, None, None, None)"))
+
+
+def test_quantity_with_unit_value(fx_quantity_with_unit: Quantity):
+    assert fx_quantity_with_unit.amount == 610.13
+    assert fx_quantity_with_unit.lower_bound == 610.12
+    assert fx_quantity_with_unit.upper_bound == 610.14
+    assert isinstance(fx_quantity_with_unit.unit, Entity)
+    assert fx_quantity_with_unit.unit.id == "Q828224"
+
+
+def test_quantity_with_unit_repr(fx_quantity_with_unit: Quantity):
+    assert (repr(fx_quantity_with_unit) ==
+            ("wikidata.quantity.Quantity(610.13, 610.12, 610.14, "
+             "<wikidata.entity.Entity Q828224>)"))

--- a/wikidata/datavalue.py
+++ b/wikidata/datavalue.py
@@ -16,11 +16,12 @@ but only need to satify::
 """
 import collections.abc
 import datetime
-from typing import TYPE_CHECKING, Mapping, Union
+from typing import TYPE_CHECKING, Any, Mapping, Union
 
 from .client import Client
 from .commonsmedia import File
 from .multilingual import MonolingualText
+from .quantity import Quantity
 if TYPE_CHECKING:
     from .entity import Entity  # noqa: F401
 
@@ -219,6 +220,34 @@ class Decoder:
                         datavalue: Mapping[str, object]) -> MonolingualText:
         pair = datavalue['value']
         return MonolingualText(pair['text'], pair['language'])  # type: ignore
+
+    def quantity(self,
+                 client: Client,
+                 datavalue: Mapping[str, Any]) -> Quantity:
+        pair = datavalue['value']
+        raw_unit = pair.get("unit", "1")
+        if raw_unit == "1":
+            # If the value is unitless, the unit has a string value "1"
+            unit = None
+        else:
+            # Try to parse the unit as an Entity.
+            unit_entity = raw_unit.split("http://www.wikidata.org/entity/")
+            if len(unit_entity) != 2:
+                raise DatavalueError(
+                    "Unit string {} does not appear to be a "
+                    "valid WikiData entity URL or \"1\"".format(raw_unit))
+            unit = client.get(unit_entity[1])
+        # Parse the amount as a float
+        amount = float(pair["amount"])
+        # Parse the lower and upper bound
+        lower_bound = pair.get('lower_bound', None)
+        lower_bound = float(lower_bound) if lower_bound else lower_bound
+        upper_bound = pair.get('upper_bound', None)
+        upper_bound = float(upper_bound) if upper_bound else upper_bound
+        return Quantity(amount,
+                        lower_bound,
+                        upper_bound,
+                        unit)
 
     def commonsMedia__string(self,
                              client: Client,

--- a/wikidata/quantity.py
+++ b/wikidata/quantity.py
@@ -1,0 +1,57 @@
+""":mod:`wikidata.quantity` --- Quantity
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+"""
+from typing import Optional
+
+from .entity import Entity
+
+__all__ = 'Quantity',
+
+
+class Quantity:
+    """A Quantity value represents a decimal number, together with information
+    about the uncertainty interval of this number, and a unit of measurement.
+    """
+
+    amount = None  # type: float
+    lower_bound = None  # type: Optional[float]
+    upper_bound = None  # type: Optional[float]
+    unit = None  # type: Optional[Entity]
+
+    def __init__(self,
+                 amount: float,
+                 lower_bound: Optional[float],
+                 upper_bound: Optional[float],
+                 unit: Optional[Entity]) -> None:
+        self.amount = amount
+        self.lower_bound = lower_bound
+        self.upper_bound = upper_bound
+        self.unit = unit
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, type(self)):
+            raise TypeError(
+                'expected an instance of {0.__module__}.{0.__qualname__}, '
+                'not {1!r}'.format(type(self), other)
+            )
+        return (other.amount == self.amount and
+                other.lower_bound == self.lower_bound and
+                other.upper_bound == self.upper_bound and
+                other.unit == self.unit)
+
+    def __hash__(self):
+        return hash((self.amount,
+                     self.lower_bound,
+                     self.upper_bound,
+                     self.unit))
+
+    def __repr__(self) -> str:
+        return ('{0.__module__}.{0.__qualname__}({1!r}, '
+                '{2!r}, {3!r}, {4!r})').format(
+                    type(self),
+                    self.amount,
+                    self.lower_bound,
+                    self.upper_bound,
+                    self.unit
+                )


### PR DESCRIPTION
This PR introduces changes to support parsing quantities. See https://www.wikidata.org/wiki/Help:Data_type#Quantity for official wikidata docs

I've been using the unitless quantity at https://www.wikidata.org/wiki/Q605704 for testing, as well as the unit-bearing (and uncertain) quantity at https://www.wikidata.org/wiki/Q520.