### PR TITLE
Remove babel from dependencies

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,8 +17,6 @@ To be released.
 - Added support for decoding the ``globe-coordinate`` datatype.  [:pr:`28`]
 - Fixed a bug that raised :exc:`~urllib.error.HTTPError` when
   non-existent `Entity` was requested.  [:pr:`11`]
-- Added support for `time` datatypes with precision `9` (year-only).  [:pr:`26`]
-- Added support for decoding the ``globe-coordinate`` datatype.  [:pr:`28`]
 - Fixed a bug that raised :exc:`KeyError` when accessing an image more than
   once and :class:`~wikidata.cache.MemoryCachePolicy` was enabled.  [:pr:`24`]
 - Removed Babel_ from the dependencies.  [:issue:`2`, :issue:`27`, :pr:`30`]

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,7 +17,7 @@ To be released.
   non-existent `Entity` was requested.  [:pr:`11`]
 - Added support for `time` datatypes with precision `9` (year-only).  [:pr:`26`]
 - Added support for decoding the ``globe-coordinate`` datatype.  [:pr:`28`]
-- Removed Babel_ from the dependencies.  [:pr:`30`]
+- Removed Babel_ from the dependencies.  [:issue:`2`, :issue:`27`, :pr:`30`]
 
 Version 0.6.1
 -------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,7 +17,7 @@ To be released.
   non-existent `Entity` was requested.  [:pr:`11`]
 - Added support for `time` datatypes with precision `9` (year-only).  [:pr:`26`]
 - Added support for decoding the ``globe-coordinate`` datatype.  [:pr:`28`]
-
+- Removed Babel_ from the dependencies.  [:pr:`30`]
 
 Version 0.6.1
 -------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -21,6 +21,9 @@ To be released.
   once and :class:`~wikidata.cache.MemoryCachePolicy` was enabled.  [:pr:`24`]
 - Removed Babel_ from the dependencies.  [:issue:`2`, :issue:`27`, :pr:`30`]
 
+  To replace the :class:`babel.core.Locale` type, the `Locale` type has been
+  aliased to `str`. This is a **breaking change** for all Wikidata public API
+  functions that formerly returned or ingested :class:`babel.core.Locale` .
 
 Version 0.6.1
 -------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -353,7 +353,6 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'babel': ('http://babel.pocoo.org/en/latest/', None),
     'python': ('https://docs.python.org/3/', None),
     'werkzeug': ('http://werkzeug.pocoo.org/docs/0.12/', None),
 }

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,9 +6,6 @@ show_none_errors = true
 strict_optional = true
 warn_unused_ignores = true
 
-[mypy-babel.core.*]
-ignore_missing_imports = true
-
 [mypy-tests.*]
 check_untyped_defs = false
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,6 @@ classifiers =
 packages = find:
 python_requires = >=3.4.0
 install_requires =
-    Babel >= 2.0
     typing; python_version<"3.5"
 
 [options.packages.find]

--- a/tests/entity_test.py
+++ b/tests/entity_test.py
@@ -2,13 +2,12 @@ import json
 from typing import Iterable
 import urllib.request
 
-from babel.core import Locale
 from pytest import raises
 
 from .mock import ENTITY_FIXTURES_PATH
 from wikidata.client import Client
 from wikidata.entity import Entity, EntityId, EntityType
-from wikidata.multilingual import MultilingualText
+from wikidata.multilingual import Locale, MultilingualText
 
 
 def test_entity_equality(fx_client_opener: urllib.request.OpenerDirector,
@@ -32,44 +31,39 @@ def test_entity_equality(fx_client_opener: urllib.request.OpenerDirector,
 def test_entity_label(fx_loaded_entity: Entity,
                       fx_unloaded_entity: Entity):
     assert isinstance(fx_loaded_entity.label, MultilingualText)
-    assert fx_loaded_entity.label[Locale.parse('ko')] == '신중현'
-    assert fx_loaded_entity.label[Locale.parse('zh_Hant')] == '申重鉉'
+    assert fx_loaded_entity.label[Locale('ko')] == '신중현'
+    assert fx_loaded_entity.label[Locale('zh-hant')] == '申重鉉'
     assert isinstance(fx_unloaded_entity.label, MultilingualText)
-    assert fx_unloaded_entity.label[Locale.parse('en')] == 'The Beatles'
-    assert fx_unloaded_entity.label[Locale.parse('ko')] == '비틀즈'
+    assert fx_unloaded_entity.label[Locale('en')] == 'The Beatles'
+    assert fx_unloaded_entity.label[Locale('ko')] == '비틀즈'
 
 
 def test_entity_description(fx_loaded_entity: Entity,
                             fx_unloaded_entity: Entity):
     assert isinstance(fx_loaded_entity.description, MultilingualText)
-    assert fx_loaded_entity.description[Locale.parse('ko')] == \
+    assert fx_loaded_entity.description[Locale('ko')] == \
         '대한민국의 록 음악 싱어송라이터 및 기타리스트'
-    assert fx_loaded_entity.description[Locale.parse('ja')] == \
+    assert fx_loaded_entity.description[Locale('ja')] == \
         '韓国のロックミュージシャン'
     assert isinstance(fx_unloaded_entity.description, MultilingualText)
-    assert fx_unloaded_entity.description[Locale.parse('en')] == \
+    assert fx_unloaded_entity.description[Locale('en')] == \
         'English rock band'
-    assert fx_unloaded_entity.description[Locale.parse('ko')] == \
+    assert fx_unloaded_entity.description[Locale('ko')] == \
         '영국의 락 밴드'
 
 
 def test_entity_label_description_three_chars_lang_codes(fx_client: Client):
-    """As a short-term workaround, we currently ignore language codes
-    ISO 639-1 doesn't cover.
-
-    See also: https://github.com/dahlia/wikidata/issues/2
-
+    """
+    Ensure that three-character language codes are handled
     """
     cbk_zam = fx_client.get(EntityId('Q33281'), load=True)
     assert isinstance(cbk_zam.label, MultilingualText)
-    assert cbk_zam.label[Locale.parse('ko')] == '차바카노어'
-    assert 'cbk-zam' not in cbk_zam.label
-    assert 'cbk_zam' not in cbk_zam.label
+    assert cbk_zam.label[Locale('ko')] == '차바카노어'
+    assert Locale('cbk-zam') in cbk_zam.label
     assert isinstance(cbk_zam.description, MultilingualText)
-    assert cbk_zam.description[Locale.parse('en')] == \
+    assert cbk_zam.description[Locale('en')] == \
         'Spanish-based creole language spoken in the Philippines'
-    assert 'cbk-zam' not in cbk_zam.description
-    assert 'cbk_zam' not in cbk_zam.description
+    assert Locale('cbk-zam') not in cbk_zam.description
 
 
 def test_entity_type(fx_item: Entity,

--- a/tests/multilingual_test.py
+++ b/tests/multilingual_test.py
@@ -1,50 +1,36 @@
-import functools
+from pytest import fixture
 
-from babel.core import Locale
-from pytest import fixture, raises
-
-from wikidata.multilingual import (MonolingualText, MultilingualText,
-                                   normalize_locale_code)
+from wikidata.multilingual import Locale, MonolingualText, MultilingualText
 
 
 @fixture
 def fx_multilingual_text() -> MultilingualText:
     return MultilingualText({
-        'ko-kr': '윤동주',
-        'ja_JP': '尹東柱',
-        'zh_Hans': '尹东柱',
-        Locale.parse('en_US'): 'Yun Dong-ju',
+        'ko': '윤동주',
+        'ja': '尹東柱',
+        'zh-hans': '尹东柱',
+        'en': 'Yun Dong-ju',
     })
 
 
 def test_multilingual_text_mapping(fx_multilingual_text: MultilingualText):
     mt = fx_multilingual_text
-    ko = functools.partial(Locale.parse, 'ko_KR')
-    ja = functools.partial(Locale.parse, 'ja_JP')
-    zh = functools.partial(Locale.parse, 'zh_Hans')
-    en = functools.partial(Locale.parse, 'en_US')
-    assert set(mt) == {ko(), ja(), zh(), en()}
+    assert set(mt) == {"ko", "ja", "zh-hans", "en"}
     assert len(mt) == 4
-    assert ko() in mt
-    assert ja() in mt
-    assert zh() in mt
-    assert en() in mt
-    assert Locale.parse('ko_KP') not in mt
-    assert Locale.parse('zh_Hant') not in mt
-    assert Locale.parse('en_GB') not in mt
-    assert mt[ko()] == mt.get(ko()) == '윤동주'
-    assert mt[ja()] == mt.get(ja()) == '尹東柱'
-    assert mt[zh()] == mt.get(zh()) == '尹东柱'
-    assert mt[en()] == mt.get(en()) == 'Yun Dong-ju'
-    with raises(KeyError):
-        mt[Locale.parse('ko_KP')]
-    assert mt.get(Locale.parse('ko_KP')) is None
-    with raises(KeyError):
-        mt[Locale.parse('zh_Hant')]
-    assert mt.get(Locale.parse('zh_Hant')) is None
-    with raises(KeyError):
-        mt[Locale.parse('en_GB')]
-    assert mt.get(Locale.parse('en_GB')) is None
+    assert Locale("ko") in mt
+    assert Locale("ja") in mt
+    assert Locale("zh-hans") in mt
+    assert Locale("en") in mt
+    assert Locale("ko-kp") not in mt
+    assert Locale("zh-hant") not in mt
+    assert Locale("en-gb") not in mt
+    assert mt[Locale("ko")] == mt.get("ko") == '윤동주'
+    assert mt[Locale("ja")] == mt.get("ja") == '尹東柱'
+    assert mt[Locale("zh-hans")] == mt.get("zh-hans") == '尹东柱'
+    assert mt[Locale("en")] == mt.get("en") == 'Yun Dong-ju'
+    assert mt.get("ko-kp") is None
+    assert mt.get('zh-hant') is None
+    assert mt.get('en-gb') is None
 
 
 def test_multilingual_text_str(fx_multilingual_text: MultilingualText):
@@ -60,26 +46,15 @@ def test_multilingual_text_repr(fx_multilingual_text: MultilingualText):
 
 def test_monolingual_text_locale():
     a = MonolingualText('윤동주', 'ko')
-    assert a.locale_code == 'ko'
-    assert a.locale == Locale.parse('ko')
-    b = MonolingualText('윤동주', Locale.parse('ko_KR'))
-    assert b.locale_code == 'ko_KR'
-    assert b.locale == Locale.parse('ko_KR')
-    c = MonolingualText('周樹人', 'zh_Hant')
-    assert c.locale_code == 'zh_Hant'
-    assert c.locale == Locale.parse('zh_Hant')
+    assert a.locale == 'ko'
+    c = MonolingualText('周樹人', 'zh-hant')
+    assert c.locale == 'zh-hant'
 
 
 def test_monolingual_text_repr():
     a = MonolingualText('윤동주', 'ko')
     assert repr(a) == "'(ko:) 윤동주'[6:]"
     assert eval(repr(a)) == str(a)
-    b = MonolingualText('周樹人', 'zh_Hant')
-    assert repr(b) == "'(zh_Hant:) 周樹人'[11:]"
+    b = MonolingualText('周樹人', 'zh-hant')
+    assert repr(b) == "'(zh-hant:) 周樹人'[11:]"
     assert eval(repr(b)) == str(b)
-
-
-def test_normalize_locale_code():
-    assert normalize_locale_code('ko-kr') == 'ko_KR'
-    assert normalize_locale_code('zh_TW') == 'zh_Hant_TW'
-    assert normalize_locale_code(Locale.parse('en_US')) == 'en_US'

--- a/wikidata/entity.py
+++ b/wikidata/entity.py
@@ -10,8 +10,6 @@ from typing import (TYPE_CHECKING, Iterator, Mapping, NewType,
                     Optional, Sequence, Tuple, Union,
                     cast)
 
-from babel.core import Locale, UnknownLocaleError
-
 from .multilingual import MultilingualText
 
 if TYPE_CHECKING:
@@ -39,15 +37,10 @@ class multilingual_attribute:
         try:
             value = obj.__dict__[cache_id]
         except KeyError:
-            def parse(locale: str) -> Optional[Locale]:
-                try:
-                    return Locale.parse(locale.replace('-', '_'))
-                except (ValueError, UnknownLocaleError):
-                    return None
             attr = obj.attributes.get(self.attribute) or {}
             assert isinstance(attr, collections.abc.Mapping)
             pairs = (
-                (parse(item['language']), item['value'])
+                (item['language'], item['value'])
                 for item in attr.values()
             )
             value = MultilingualText({k: v for k, v in pairs if k})

--- a/wikidata/multilingual.py
+++ b/wikidata/multilingual.py
@@ -59,7 +59,7 @@ class MonolingualText(str):
     :attr:`locale`, that denotes what language the text is written in.
     """
 
-    #: (:class:`str`) The code of :attr:`locale`.
+    #: (:class:`Locale`) The code of :attr:`locale`.
     locale = None  # type: Locale
 
     def __new__(cls: Type[str],

--- a/wikidata/multilingual.py
+++ b/wikidata/multilingual.py
@@ -5,7 +5,7 @@
 import collections.abc
 from typing import Iterator, Mapping, NewType, Type, Union
 
-__all__ = 'MonolingualText', 'MultilingualText'
+__all__ = 'Locale', 'MonolingualText', 'MultilingualText'
 
 
 #: The locale of each :class:`MonolingualText` or internal

--- a/wikidata/multilingual.py
+++ b/wikidata/multilingual.py
@@ -9,7 +9,7 @@ __all__ = 'Locale', 'MonolingualText', 'MultilingualText'
 
 
 #: The locale of each :class:`MonolingualText` or internal
-#  mapping of each :class:`MultilingualText`.  Alias of :class:`str`.
+#:  mapping of each :class:`MultilingualText`.  Alias of :class:`str`.
 Locale = NewType('Locale', str)
 
 

--- a/wikidata/multilingual.py
+++ b/wikidata/multilingual.py
@@ -3,11 +3,14 @@
 
 """
 import collections.abc
-from typing import Iterator, Mapping, Type, Union
+from typing import Iterator, Mapping, NewType, Type, Union
 
-from babel.core import Locale
+__all__ = 'MonolingualText', 'MultilingualText'
 
-__all__ = 'MonolingualText', 'MultilingualText', 'normalize_locale_code'
+
+#: The locale of each :class:`MonolingualText` or internal
+#  mapping of each :class:`MultilingualText`.  Alias of :class:`str`.
+Locale = NewType('Locale', str)
 
 
 class MultilingualText(collections.abc.Mapping):
@@ -15,27 +18,27 @@ class MultilingualText(collections.abc.Mapping):
     __slots__ = 'texts',
 
     def __init__(self, texts: Mapping[Union[Locale, str], str]) -> None:
-        self.texts = {normalize_locale_code(lc): t for lc, t in texts.items()}
+        self.texts = {Locale(lc): t for lc, t in texts.items()}
 
     def __iter__(self) -> Iterator[Locale]:
-        for locale_code in self.texts:
-            yield Locale.parse(locale_code)
+        for locale in self.texts:
+            yield locale
 
     def __len__(self) -> int:
         return len(self.texts)
 
-    def __contains__(self, locale: Locale) -> bool:
-        return str(locale) in self.texts
+    def __contains__(self, locale: Locale) -> bool:  # type: ignore[override]
+        return locale in self.texts
 
     def __getitem__(self, locale: Locale) -> str:
-        return self.texts[str(locale)]
+        return self.texts[locale]
 
     def __bool__(self) -> bool:
         return bool(self.texts)
 
     def __str__(self) -> str:
         try:
-            return self.texts['en']
+            return self.texts[Locale('en')]
         except KeyError:
             value = ''
             for lang, value in self.texts.items():
@@ -50,47 +53,22 @@ class MultilingualText(collections.abc.Mapping):
 
 
 class MonolingualText(str):
-    """Locale-denoted text.  It's almost equivalent to :class:`str`
-    (and indeed subclasses :class:`str`) except that it has two more
-    attribute: :attr:`locale` and :attr:`locale_code` that denote
-    what language the text is written in.
-
+    """
+    Locale-denoted text. It's almost equivalent to :class:`str` (and indeed
+    subclasses :class:`str`) except that it has an extra attribute,
+    :attr:`locale`, that denotes what language the text is written in.
     """
 
     #: (:class:`str`) The code of :attr:`locale`.
-    locale_code = None  # type: Locale
+    locale = None  # type: Locale
 
     def __new__(cls: Type[str],
                 text: str,
                 locale: Union[Locale, str]) -> 'MonolingualText':
         self = str.__new__(cls, text)  # type: ignore
-        self.locale_code = normalize_locale_code(locale)
+        self.locale = locale
         return self
 
-    @property
-    def locale(self) -> Locale:
-        """(:class:`~babel.core.Locale`) The language (locale) that the text is
-        written in.
-
-        """
-        return Locale.parse(self.locale_code)
-
     def __repr__(self) -> str:
-        altrepr = '({0}:) {1!s}'.format(self.locale_code, self)
-        return '{0!r}[{1}:]'.format(altrepr, len(self.locale_code) + 4)
-
-
-def normalize_locale_code(locale: Union[Locale, str]) -> str:
-    """Determine the normalized locale code string.
-
-    >>> normalize_locale_code('ko-kr')
-    'ko_KR'
-    >>> normalize_locale_code('zh_TW')
-    'zh_Hant_TW'
-    >>> normalize_locale_code(Locale.parse('en_US'))
-    'en_US'
-
-    """
-    if not isinstance(locale, Locale):
-        locale = Locale.parse(locale.replace('-', '_'))
-    return str(locale)
+        altrepr = '({0}:) {1!s}'.format(self.locale, self)
+        return '{0!r}[{1}:]'.format(altrepr, len(self.locale) + 4)


### PR DESCRIPTION
Fixes #2 #27

This removes babel from the dependencies, and just aliases `Locale` to `str`.