### PR TITLE
Fix #39 (Replace Travis CI with GitHub Actions)

### DIFF
--- a/.github/workflows/python-wf.yml
+++ b/.github/workflows/python-wf.yml
@@ -19,7 +19,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8'] # only apply to 3.8 during testing
+        # python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2
@@ -27,15 +28,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Display marker
-      run: echo "+++++++++++++++"
     - name: Display Python version
       run: python --version
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install tox tox-gh-actions
-    - name: Display 2nd marker
-      run: echo "~~~~~~~~~~~~~~"
     - name: Test with tox
       run: tox

--- a/.github/workflows/python-wf.yml
+++ b/.github/workflows/python-wf.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-wf.yml
+++ b/.github/workflows/python-wf.yml
@@ -1,6 +1,10 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
+# this file uses sections
+# - https://github.com/actions/setup-python#usage
+# - from https://github.com/ymyzk/tox-gh-actions#examples
+
 name: Python application
 
 on:
@@ -18,10 +22,20 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Display Python version
-        run: python --version
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Display marker
+      run: echo "+++++++++++++++"
+    - name: Display Python version
+      run: python --version
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install tox tox-gh-actions
+    - name: Display 2nd marker
+      run: echo "~~~~~~~~~~~~~~"
+    - name: Test with tox
+      run: tox

--- a/.github/workflows/python-wf.yml
+++ b/.github/workflows/python-wf.yml
@@ -19,8 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8'] # only apply to 3.8 during testing
-        # python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-wf.yml
+++ b/.github/workflows/python-wf.yml
@@ -1,0 +1,27 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python application
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Display Python version
+        run: python --version

--- a/tox.ini
+++ b/tox.ini
@@ -18,5 +18,20 @@ whitelist_externals = echo
 extras = tests
 pip_version = pip
 commands =
-    echo "---"
+    echo "+++++"
     echo "{envname}"
+    echo "-----"
+    pytest {posargs:}
+
+
+[testenv:docs]
+whitelist_externals = echo
+basepython = python3
+deps =
+    rstcheck
+    Sphinx >= 3.0, < 4.0
+    sphinx_rtd_theme
+commands =
+    echo "----- docs ---"
+    rstcheck -r .
+    python3 setup.py build_sphinx --build-dir=docs/_build

--- a/tox.ini
+++ b/tox.ini
@@ -18,20 +18,31 @@ whitelist_externals = echo
 extras = tests
 pip_version = pip
 commands =
-    echo "+++++"
     echo "{envname}"
-    echo "-----"
     pytest {posargs:}
 
+[testenv:mypy]
+whitelist_externals = echo
+extras = mypy
+basepython = python3
+commands =
+    echo "-----------"
+    echo "{envname}"
+    mypy -p wikidata
+    mypy -p tests
+
+
+# currently unused envs:
+
+[testenv:py34]
+pip_version = pip < 19.2
 
 [testenv:docs]
-whitelist_externals = echo
 basepython = python3
 deps =
     rstcheck
     Sphinx >= 3.0, < 4.0
     sphinx_rtd_theme
 commands =
-    echo "----- docs ---"
     rstcheck -r .
     python3 setup.py build_sphinx --build-dir=docs/_build

--- a/tox.ini
+++ b/tox.ini
@@ -2,30 +2,20 @@
 envlist =
     # CHECK If you're going to change the list of supported Python versions
     # update .travis.yml and setup.py's classifiers as well.
-    py34, py35, py36, py37, py38, pypy3, mypy
+    py34, py35, py36, py37, py38, py39, py310, mypy
+
+
+
+[gh-actions]
+python =
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310, mypy
 
 [testenv]
 extras = tests
 pip_version = pip
 commands =
-    pytest {posargs:}
-
-[testenv:py34]
-pip_version = pip < 19.2
-
-[testenv:mypy]
-extras = mypy
-basepython = python3
-commands =
-    mypy -p wikidata
-    mypy -p tests
-
-[testenv:docs]
-basepython = python3
-deps =
-    rstcheck
-    Sphinx >= 3.0, < 4.0
-    sphinx_rtd_theme
-commands =
-    rstcheck -r .
-    python3 setup.py build_sphinx --build-dir=docs/_build
+    echo "---"
+    echo "{envname}"

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ python =
     3.10: py310, mypy
 
 [testenv]
+whitelist_externals = echo
 extras = tests
 pip_version = pip
 commands =


### PR DESCRIPTION
This is an attempt to move from travis (discontinued free service) to github actions, see #39.

There are still some issues open questions:

- Tests for py3.10 fail, see https://github.com/cknoll/wikidata/actions/ (I hope you have access to the log details). I think, however, this is a separate issue (not related to new test setup).
- The whole magic with https://github.com/spoqa/checkmate/... from [.travis.yml](https://github.com/dahlia/wikidata/blob/66fd0028da3a8096149a02d8928710314a3c2f1e/.travis.yml#L9) is not included because I did not yet understand what it does and whether it can/should be ported to gh actions.
- I have dropped testing support for python versions < 3.6 because I think users