### PR TITLE
add precision 7

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,7 +15,7 @@ To be released.
   were incorrectly typed.
 - :class:`wikidata.multilingual.MultilingualText`'s constructor became to take
   only :class:`Locale` for parameter ``locale``.
-
+- Added date precision 7 in :class:`wikidata.datavalue.decoder` [:pr:`59`]
 
 Version 0.7.0
 -------------

--- a/tests/datavalue_test.py
+++ b/tests/datavalue_test.py
@@ -130,11 +130,11 @@ def test_decoder__time(datatype: str, fx_client: Client):
         d(fx_client, datatype, other_value(precision=None))
         # precision field is missing
     for p in range(1, 15):
-        if p in (9, 11, 14):
+        if p in (7, 9, 11, 14):
             continue
         with raises(DatavalueError):
             d(fx_client, datatype, other_value(precision=p))
-            # precision (other than 11 or 14) is unsupported
+            # precision (other than 7, 9, 11 or 14) is unsupported
 
 
 def test_decoder_monolingualtext(fx_client: Client):

--- a/wikidata/datavalue.py
+++ b/wikidata/datavalue.py
@@ -193,6 +193,8 @@ class Decoder:
             precision = value['precision']
         except KeyError:
             raise DatavalueError('precision field is missing', datavalue)
+        if precision == 7:
+            return int(time[1:3])
         if precision == 9:
             # The time only specifies the year.
             return int(time[1:5])
@@ -206,7 +208,7 @@ class Decoder:
             ).replace(tzinfo=datetime.timezone.utc)
         else:
             raise DatavalueError(
-                '{!r}: time precision other than 9, 11 or 14 is '
+                '{!r}: time precision other than 7, 9, 11 or 14 is '
                 'unsupported'.format(precision),
                 datavalue
             )


### PR DESCRIPTION
Following the issue #58 I create this pull request.
I propose this change to fix this error `7: time precision other than 9, 11 or 14 is unsupported wikidata {'type': 'time', 'value': {'time': '+2000-00-00T00:00:00Z', 'timezone': 0, 'before': 0, 'after': 0, 'precision': 7, 'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'}}.`
