### PR TITLE
time precision 10

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -36,7 +36,7 @@ on all of them.
 
 The easiest to install ``tox`` is to use ``pip`` [#]_::
 
-    pip install tox tox-pip-version
+    pip install tox
 
 Once you've installed ``tox``, it's very simple to run the test suite on
 all Python versions this project aims to support::

--- a/tests/datavalue_test.py
+++ b/tests/datavalue_test.py
@@ -130,11 +130,11 @@ def test_decoder__time(datatype: str, fx_client: Client):
         d(fx_client, datatype, other_value(precision=None))
         # precision field is missing
     for p in range(1, 15):
-        if p in (7, 9, 11, 14):
+        if p in (7, 9, 10, 11, 14):
             continue
         with raises(DatavalueError):
             d(fx_client, datatype, other_value(precision=p))
-            # precision (other than 7, 9, 11 or 14) is unsupported
+            # precision (other than 7, 9, 10, 11 or 14) is unsupported
 
 
 def test_decoder_monolingualtext(fx_client: Client):

--- a/wikidata/datavalue.py
+++ b/wikidata/datavalue.py
@@ -11,7 +11,7 @@ but only need to satify::
 """
 import collections.abc
 import datetime
-from typing import TYPE_CHECKING, Any, Mapping, Union
+from typing import TYPE_CHECKING, Any, Mapping, Union, Tuple
 
 from .client import Client
 from .commonsmedia import File
@@ -147,6 +147,7 @@ class Decoder:
              client: Client,
              datavalue: Mapping[str, object]) -> Union[datetime.date,
                                                        datetime.datetime,
+                                                       Tuple[int, int],
                                                        int]:
         value = datavalue['value']
         if not isinstance(value, collections.abc.Mapping):

--- a/wikidata/datavalue.py
+++ b/wikidata/datavalue.py
@@ -211,7 +211,7 @@ class Decoder:
             ).replace(tzinfo=datetime.timezone.utc)
         else:
             raise DatavalueError(
-                '{!r}: time precision other than 7, 9, 11 or 14 is '
+                '{!r}: time precision other than 7, 9, 10, 11 or 14 is '
                 'unsupported'.format(precision),
                 datavalue
             )

--- a/wikidata/datavalue.py
+++ b/wikidata/datavalue.py
@@ -11,7 +11,7 @@ but only need to satify::
 """
 import collections.abc
 import datetime
-from typing import TYPE_CHECKING, Any, Mapping, Union, Tuple
+from typing import TYPE_CHECKING, Any, Mapping, Tuple, Union
 
 from .client import Client
 from .commonsmedia import File

--- a/wikidata/datavalue.py
+++ b/wikidata/datavalue.py
@@ -198,6 +198,9 @@ class Decoder:
         if precision == 9:
             # The time only specifies the year.
             return int(time[1:5])
+        if precision == 10:
+            # this time only specifies year and month (no day)
+            return (int(time[1:5]), int(time[6:8]))
         if precision == 11:
             return datetime.date(int(time[1:5]), int(time[6:8]),
                                  int(time[9:11]))


### PR DESCRIPTION
Dear maintainer,

Please find a proposal for the management of time values associated to a precision argument of value 10.
This value is used for dates containing only year and month (no day).
See https://www.wikidata.org/wiki/Help:Dates#Precision

I chose to return a tuple (year, month) in this situation, since the python datetime requires a day, and that a single int value is used when the year only is used. This choice allow to distinguish between the different time precisions that could be used.

I also updated the test set.

Let me know if this proposal is consistent with your project.

Kind regards,
